### PR TITLE
Use markdown formatting for links (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # eShopOnWeb
 
-Sample ASP.NET Core reference application, powered by Microsoft, demonstrating a monolithic application architecture and deployment model. This reference application is meant to support the <a href='https://aka.ms/webappebook'>[Architecting and Developing Modern Web Applications with ASP.NET Core and Azure eBook]</a>
+Sample ASP.NET Core reference application, powered by Microsoft, demonstrating a monolithic application architecture and deployment model. This reference application is meant to support the [Architecting and Developing Modern Web Applications with ASP.NET Core and Azure eBook](https://aka.ms/webappebook)
 
-The **eShopOnWeb** is related to the <a href='https://github.com/dotnet/eShopOnContainers'>eShopOnContainers</a> sample application which, in that case, focuses on a microservices/containers based application architecture. However, **eShopOnWeb** is much simpler in regards its current functionality and focuses on traditional Web Application Development with a single monolithic deployment, no microservices/containers related.
+The **eShopOnWeb** is related to the [eShopOnContainers](https://github.com/dotnet/eShopOnContainers) sample application which, in that case, focuses on a microservices/containers based application architecture. However, **eShopOnWeb** is much simpler in regards its current functionality and focuses on traditional Web Application Development with a single monolithic deployment, no microservices/containers related.
 
 > ### DISCLAIMER
 > **IMPORTANT:** The current state of this sample application is **ALPHA**, consider it a 0.1 foundational version. Therefore areas will change significantly while refactoring current code and implementing new features. **Feedback with improvements and pull requests from the community are highly appreciated and accepted.**


### PR DESCRIPTION
This PR replaces the html formatting for links with markdown's own formatting. Why markdown formatting should be used over HTML (in markdown) is better explained by [John Gruber](https://daringfireball.net/projects/markdown/syntax#html).

> The idea for Markdown is to make it easy to read, write, and edit prose. HTML is a publishing format; Markdown is a writing format. Thus, Markdown’s formatting syntax only addresses issues that can be conveyed in plain text.